### PR TITLE
Fix bad buffer-> string conversion on node

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,7 +20,8 @@ export const atob: Function = isBrowser
   ? window.atob
   : (input: string): Buffer => {
       const decoded = Buffer.from(input, "base64");
-      return decoded;
+      const str = String.fromCharCode.apply(null, decoded);
+      return str;
     };
 
 export const btoa: Function = isBrowser


### PR DESCRIPTION
Current code returns a Uint8Array on node, which causes an exception to be thrown in node.

This would also be fixed by https://github.com/hMatoba/exif-library/issues/10